### PR TITLE
Add random seed to test_ml_logger

### DIFF
--- a/ml_logger_tests/test_ml_logger.py
+++ b/ml_logger_tests/test_ml_logger.py
@@ -60,6 +60,7 @@ def test_glob(setup):
 
 def test_log_data(setup):
     import numpy
+    numpy.random.seed(0)
     d1 = numpy.random.randn(20, 10)
     logger.log_data(d1, 'test_file.pkl')
     sleep(0.1)
@@ -75,6 +76,7 @@ def test_log_data(setup):
 
 def test_save_pkl_abs_path(setup):
     import numpy
+    numpy.random.seed(0)
 
     d1 = numpy.random.randn(20, 10)
     logger.save_pkl(d1, "/tmp/ml-logger-test/test_file_1.pkl")


### PR DESCRIPTION
Hi, this PR adds `numpy.random.seed(0)` to `test_log_data` and `test_save_pkl_abs_path` in `ml_logger_tests/test_ml_logger.py` to ensure reproducible random numbers. Currently, these tests use `numpy.random.randn` without a fixed seed, which can lead to inconsistent results. 

The file `test_summary_cache.py` already uses a seed, and this change follows that pattern.

If you want, I can move the import to the start of the file and uses one seed after the import...
